### PR TITLE
refactor(components): Use default imports where possible

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import Offense from "./Offense";
 import Defense from "./Defense";

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as classnames from "classnames";
+import React from "react";
+import classnames from "classnames";
 
 function buttonClass(disabled: boolean) {
   return classnames(

--- a/src/Defense.tsx
+++ b/src/Defense.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import TypeSelector from "./TypeSelector";
 import * as Matchups from "./Matchups";

--- a/src/Dex.tsx
+++ b/src/Dex.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
-import * as classnames from "classnames";
-import * as _ from "lodash";
+import React from "react";
+import classnames from "classnames";
+import _ from "lodash";
 
 import Paginator from "./Paginator";
 import Search from "./Search";

--- a/src/Matchups.tsx
+++ b/src/Matchups.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as classnames from "classnames";
+import React from "react";
+import classnames from "classnames";
 
 import {
   Type,

--- a/src/Offense.tsx
+++ b/src/Offense.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 import { Type } from "./data";
 import TypeSelector from "./TypeSelector";

--- a/src/Paginator.tsx
+++ b/src/Paginator.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as classnames from "classnames";
+import React from "react";
+import classnames from "classnames";
 
 import Button from "./Button";
 

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as classnames from "classnames";
+import React from "react";
+import classnames from "classnames";
 
 import ImageClear from "../svg/clear.svg";
 import ImageSearch from "../svg/search.svg";

--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -1,7 +1,7 @@
-import * as React from "react";
-import * as classnames from "classnames";
+import React from "react";
+import classnames from "classnames";
 
-import * as GA from "./ga";
+import { clickNav } from "./ga";
 
 function makeTab(
   props: TabContainerProps,
@@ -27,7 +27,7 @@ function makeTab(
   };
   const onClick = () => {
     changeTab(index);
-    GA.clickNav(name);
+    clickNav(name);
   };
   return (
     <button

--- a/src/TypeSelector.tsx
+++ b/src/TypeSelector.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
-import * as classnames from "classnames";
+import React from "react";
+import classnames from "classnames";
 
 import * as Data from "./data";
 import { Type } from "./data";

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
-import * as React from "react";
+import React from "react";
 import { render } from "react-dom";
-import * as SmoothScroll from "smoothscroll-polyfill";
+import SmoothScroll from "smoothscroll-polyfill";
 
 import "../less/style.less";
 import App from "./App";


### PR DESCRIPTION
No need to import them as namespaces when they arent used. Default imports
work just as well (and some were suggested by vscode).