### PR TITLE
Make search take focus on opening pokedex; add cmd-f shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,13 @@
 import classnames from "classnames";
 import * as React from "react";
-import { Link, NavLink, Redirect, Route, Switch } from "react-router-dom";
+import {
+  Link,
+  NavLink,
+  Redirect,
+  Route,
+  Switch,
+  useHistory,
+} from "react-router-dom";
 import { CoverageType, Pokemon } from "./data";
 import ScreenDefense from "./ScreenDefense";
 import ScreenInfo from "./ScreenInfo";
@@ -8,6 +15,7 @@ import ScreenOffense from "./ScreenOffense";
 import ScreenPokedex from "./ScreenPokedex";
 import ScreenPokedexHelp from "./ScreenPokedexHelp";
 import ScreenWeaknessCoverage from "./ScreenWeaknessCoverage";
+import useShortcut, { cmdCtrlKey } from "./useShortcut";
 
 const tabClass = classnames([
   "no-underline",
@@ -22,6 +30,7 @@ const tabClass = classnames([
 const tabClassActive = classnames(["fg1 bottom-border-thick-current"]);
 
 export default function App() {
+  const history = useHistory();
   const [defenseParams, setDefenseParams] = React.useState("");
   const [offenseParams, setOffenseParams] = React.useState("");
   const [pokedexParams, setPokedexParams] = React.useState("");
@@ -31,6 +40,18 @@ export default function App() {
     CoverageType[]
   >([]);
   const [AllPokemon, setAllPokemon] = React.useState<Pokemon[]>([]);
+
+  // Navigate to pokedex page on pressing cmd/ctrl-f
+  useShortcut(
+    (event: KeyboardEvent): void => {
+      if (event[cmdCtrlKey] && event.key === "f") {
+        event.preventDefault();
+        history.push(`/pokedex${pokedexParams}`);
+      }
+    },
+    [history, pokedexParams]
+  );
+
   React.useEffect(() => {
     async function load() {
       const bigPKMN = await import(

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -1,6 +1,7 @@
 import classnames from "classnames";
 import * as React from "react";
 import { PUBLIC_PATH } from "./settings";
+import useShortcut, { cmdCtrlKey } from "./useShortcut";
 
 interface SearchProps {
   updateSearch: (search: string) => void;
@@ -18,6 +19,23 @@ export default function Search({ updateSearch, search }: SearchProps) {
   const ref = React.useRef<HTMLInputElement>(null);
   const iconSize = 24;
   const inputHeight = 36;
+
+  // Select contents of search input when switching to the page
+  React.useEffect(() => {
+    ref?.current?.select();
+  }, [ref]);
+
+  // Select contents of search input when pressing cmd/ctrl-f
+  useShortcut(
+    (event: KeyboardEvent): void => {
+      if (event[cmdCtrlKey] && event.key === "f") {
+        event.preventDefault();
+        ref?.current?.select();
+      }
+    },
+    [ref]
+  );
+
   return (
     <div className="relative mv3">
       <img

--- a/src/useShortcut.tsx
+++ b/src/useShortcut.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { DependencyList } from "react";
+
+export const cmdCtrlKey = navigator.platform.includes("Mac")
+  ? "metaKey"
+  : "ctrlKey";
+
+export default function useShortcut(
+  listener: (event: KeyboardEvent) => void,
+  deps: DependencyList
+) {
+  React.useEffect(() => {
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, [listener, ...deps]);
+}


### PR DESCRIPTION
I added some convenience functionality because I wanted it; I think it makes the website a little bit nicer to use.

This adds some convenience behavior:
- Cmd/Ctrl-F changes page to the Pokedex page
- The search input is focused by default, or if you press cmd-f again on the pokedex page
- The input text is selected by default, so you don't have to delete the contents before typing a new search

Basically, this makes the pokedex search page behave roughly like the browser find-in-page.