### PR TITLE
Respect OS level screen rotation locks

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "pkmn.help",
   "lang": "en",
   "start_url": "/",
-  "orientation": "any",
+  "orientation": "natural",
   "icons": [
     {
       "src": "/favicon-16.png",


### PR DESCRIPTION
Currently the installed PWA does not respect the OS level rotation lock.

Using `"orientation": "natural"` fixes this.

See: https://meta.discourse.org/t/manifest-orientation-property/94900
https://www.w3.org/TR/screen-orientation/#dfn-natural