### PR TITLE
Update the colors again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 2025-06-26
+
+- Removed the shiny gradient on buttons, it was too distracting
+
+  - It's just a subtle regular gradient now
+
+- Updated the color scheme to be blue tinted again
+
+  - Yes, you were right, person who emailed me about this
+
+- Further refined the Pokédex card styles
+
+- Updated the Defense Team page styles to better match the Pokédex card styles
+
+  - There was a lot of wasted space and visual noise on that page before
+
+  - I think it's easier to read now
+
+  - I also changed the size at which it switches to two column mode, so the team
+    edit area has more room
+
 ## 2025-06-25
 
 - Updated "Rocha" (Rock) to "Pedra" in Portuguese (Portugal)

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -241,7 +241,7 @@
 }
 
 .tab[aria-current="page"] {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--color-bg1);
+  border-color: var(--color-vibrant-border);
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
 }

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -15,12 +15,6 @@
   box-shadow: var(--shadow-button);
 }
 
-@media (hover) {
-  .root:where(:not(:disabled)):hover {
-    background: var(--background-button-bg-hover);
-  }
-}
-
 .root:disabled {
   pointer-events: none;
   background: transparent;
@@ -29,7 +23,7 @@
 }
 
 .root[aria-pressed="true"] {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--color-bg1);
+  border-color: var(--color-vibrant-border);
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
 }

--- a/src/components/Card.module.css
+++ b/src/components/Card.module.css
@@ -1,10 +1,13 @@
 .Card {
   display: flex;
   flex-direction: column;
-  border-radius: var(--border-radius2);
-  background: var(--color-bg1);
   color: var(--color-fg1);
-  box-shadow: var(--shadow-button);
-  border: 1px solid var(--color-border2);
+  background:
+    radial-gradient(100% 64px at top, var(--color-bg1), var(--color-bg2))
+      padding-box,
+    linear-gradient(var(--color-bg1), var(--color-bg2) 64px, var(--color-bg2))
+      border-box var(--color-bg2);
   padding: var(--padding3);
+  border-radius: var(--border-radius3);
+  border: 1px solid transparent;
 }

--- a/src/components/CheckboxGroup.module.css
+++ b/src/components/CheckboxGroup.module.css
@@ -19,8 +19,8 @@
 .label:where(:has(.checkbox:checked)) {
   box-shadow: var(--shadow-button);
   border-color: var(--color-vibrant-border1);
-  background: var(--color-accent);
-  color: var(--color-bg1);
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
 }
 
 .label:where(:not(:has(.checkbox:checked))) {
@@ -28,10 +28,6 @@
   background: var(--background-button-bg);
   color: var(--color-fg1);
   box-shadow: var(--shadow-button);
-}
-
-.label:where(:not(:has(.checkbox:checked))):hover {
-  background: var(--background-button-bg-hover);
 }
 
 .checkbox {
@@ -45,8 +41,8 @@
   height: 1.5rem;
   flex: none;
   border: 0;
-  background: var(--type-color);
-  color: white;
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
   box-shadow: var(--checkbox-border);
   border-radius: 0.125rem;
 }

--- a/src/components/CopyButton.module.css
+++ b/src/components/CopyButton.module.css
@@ -8,10 +8,6 @@
   border-color: var(--color-border1);
 }
 
-.CopyButton:hover {
-  background: var(--background-button-bg-hover);
-}
-
 .CopyButton[data-state="copied"] {
   box-shadow: none;
   background: var(--color-bg2);

--- a/src/components/DefenseTabs.module.css
+++ b/src/components/DefenseTabs.module.css
@@ -8,7 +8,7 @@
 }
 
 .tab[aria-current="page"] {
-  background: var(--color-accent);
-  color: var(--color-bg1);
-  border-color: transparent;
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
+  border-color: var(--color-vibrant-border);
 }

--- a/src/components/Divider.module.css
+++ b/src/components/Divider.module.css
@@ -3,7 +3,7 @@
   border-image: linear-gradient(
       to right,
       transparent,
-      var(--color-border3),
+      var(--color-border3) 64px calc(100% - 64px),
       transparent
     )
     1;

--- a/src/components/EmptyState.module.css
+++ b/src/components/EmptyState.module.css
@@ -3,7 +3,7 @@
   font-size: 1.25rem;
   font-weight: var(--weight-medium);
   border: 1px solid var(--color-border3);
-  border-radius: var(--border-radius2);
+  border-radius: var(--border-radius3);
   padding: var(--padding4) var(--padding2);
   text-align: center;
 }

--- a/src/components/ExternalLink.module.css
+++ b/src/components/ExternalLink.module.css
@@ -4,11 +4,11 @@
 }
 
 @media (hover) {
-  .link:hover {
-    color: var(--color-link-hover);
+  .noUnderline:hover {
+    text-decoration-line: underline;
   }
 }
 
 .noUnderline {
-  text-decoration: none;
+  text-decoration-line: none;
 }

--- a/src/components/FancyLink.module.css
+++ b/src/components/FancyLink.module.css
@@ -4,11 +4,11 @@
 }
 
 @media (hover) {
-  .link:hover {
-    color: var(--color-link-hover);
+  .noUnderline:hover {
+    text-decoration-line: underline;
   }
 }
 
 .noUnderline {
-  text-decoration: none;
+  text-decoration-line: none;
 }

--- a/src/components/IconButton.module.css
+++ b/src/components/IconButton.module.css
@@ -16,19 +16,8 @@
   filter: var(--filter-darken);
 }
 
-@media (hover) {
-  .root:hover {
-    background: var(--color-button-hover1)
-      linear-gradient(
-        to bottom,
-        var(--color-button-hover1) 20%,
-        var(--color-button-hover1b)
-      );
-  }
-}
-
 .root[aria-pressed="true"] {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--color-bg1);
+  border-color: var(--color-vibrant-border);
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
 }

--- a/src/components/MatchupsTeam.module.css
+++ b/src/components/MatchupsTeam.module.css
@@ -1,10 +1,5 @@
 .root {
   --border: var(--color-border2);
-  border-radius: var(--border-radius2);
-  border: 1px solid var(--border);
-  box-shadow: var(--shadow-button);
-  background: var(--color-bg1);
-  padding: var(--padding2);
 }
 
 .tableWrapper {
@@ -19,13 +14,14 @@
 
 .td {
   min-width: 4rem;
-  border: 1px solid var(--border);
+  border: 1px solid var(--color-border3);
   padding: var(--padding2) var(--padding3);
   font-size: 1.25rem;
+  background: var(--color-button1);
 }
 
 .td:not([data-count="0"]) {
-  background: var(--color-bg2);
+  background: var(--color-button1b);
 }
 
 .td[data-count="0"] {
@@ -46,6 +42,6 @@
 .thTop {
   padding: var(--padding2);
   font-weight: var(--weight-medium);
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border3);
   min-width: 4rem;
 }

--- a/src/components/Monster.module.css
+++ b/src/components/Monster.module.css
@@ -5,10 +5,11 @@
   display: flex;
   color: var(--color-fg1);
   background: radial-gradient(
-    100% 50% at top,
-    var(--color-bg1),
-    var(--color-bg2)
-  );
+      50% 20% at top,
+      var(--color-bg1),
+      var(--color-bg1b)
+    )
+    var(--color-bg2);
   padding: var(--padding3);
   border-radius: var(--border-radius3);
 }

--- a/src/components/Monster.module.css
+++ b/src/components/Monster.module.css
@@ -4,14 +4,14 @@
   position: relative;
   display: flex;
   color: var(--color-fg1);
-  background: radial-gradient(
-      50% 20% at top,
-      var(--color-bg1),
-      var(--color-bg1b)
-    )
-    var(--color-bg2);
+  background:
+    radial-gradient(100% 256px at top, var(--color-bg1), var(--color-bg2))
+      padding-box,
+    linear-gradient(var(--color-bg1), var(--color-bg2) 256px) border-box
+      var(--color-bg2);
   padding: var(--padding3);
   border-radius: var(--border-radius3);
+  border: 1px solid transparent;
 }
 
 .buttonContainer {

--- a/src/components/MultiTypeSelector.module.css
+++ b/src/components/MultiTypeSelector.module.css
@@ -26,12 +26,6 @@
   box-shadow: var(--shadow-button);
 }
 
-@media (hover) {
-  .label:where(:not(:has(.checkbox:checked))):hover {
-    background: var(--background-button-bg-hover);
-  }
-}
-
 .label[data-type="stellar"]:has(.checkbox:checked) {
   background: var(--stellar-background-dark);
 }

--- a/src/components/RadioGroup.module.css
+++ b/src/components/RadioGroup.module.css
@@ -34,24 +34,13 @@
   width: 100%;
 }
 
-@media (hover) {
-  .item:hover {
-    background: linear-gradient(
-      var(--color-button-hover1),
-      var(--color-button-hover1b)
-    );
-    background: var(--background-button-bg-hover);
-    border-color: var(--color-border1);
-  }
-}
-
 .itemDivider {
   margin-block: -1px;
   border-top: 1px solid var(--color-border3);
   border-image: linear-gradient(
       to right,
       transparent,
-      var(--color-border3),
+      var(--color-border3) 64px calc(100% - 64px),
       transparent
     )
     1;
@@ -75,8 +64,8 @@
 
 .radio:checked {
   background:
-    linear-gradient(var(--color-bg1) 0 100%) content-box,
-    linear-gradient(var(--color-accent) 0 100%) border-box;
+    linear-gradient(var(--color-accent-fg) 0 100%) content-box,
+    linear-gradient(var(--color-accent-bg) 0 100%) border-box;
   border-color: var(--color-vibrant-border);
 }
 

--- a/src/components/RadioGroup.module.css
+++ b/src/components/RadioGroup.module.css
@@ -29,7 +29,7 @@
   padding: calc(1px + var(--padding2)) var(--padding2);
   gap: var(--padding3);
   align-items: center;
-  border-radius: calc(var(--border-radius3) - var(--padding1));
+  border-radius: calc(var(--border-radius2) - var(--padding1));
   border: 1px solid transparent;
   width: 100%;
 }

--- a/src/components/Select.module.css
+++ b/src/components/Select.module.css
@@ -19,12 +19,6 @@
   box-shadow: var(--shadow-button);
 }
 
-@media (hover) {
-  .select select:hover {
-    background: var(--background-button-bg-hover);
-  }
-}
-
 .select:after {
   --_size: 0.5rem;
   --_border-size: 2px;

--- a/src/screens/ScreenDefenseTeam.module.css
+++ b/src/screens/ScreenDefenseTeam.module.css
@@ -6,8 +6,8 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
-@media (width >= 64rem) {
+@media (width >= 80rem) {
   .root {
-    grid-template-columns: 4fr 6fr;
+    grid-template-columns: 3fr 4fr;
   }
 }

--- a/src/screens/ScreenDefenseTeam.tsx
+++ b/src/screens/ScreenDefenseTeam.tsx
@@ -191,7 +191,7 @@ export function ScreenDefenseTeam(): ReactNode {
             <FancyText tag="h2" fontSize="large" fontWeight="medium">
               {t("defense.team.heading")}
             </FancyText>
-            <Flex direction="column" gap="large">
+            <Flex direction="column">
               {teamTypes.length === 0 && (
                 <EmptyState>{t("defense.team.empty")}</EmptyState>
               )}

--- a/src/screens/ScreenError.module.css
+++ b/src/screens/ScreenError.module.css
@@ -5,7 +5,7 @@
   color: var(--color-fg1);
   padding: var(--padding2);
   border: 1px solid var(--color-border2);
-  border-radius: var(--border-radius2);
+  border-radius: var(--border-radius3);
   white-space: pre-wrap;
   word-break: break-all;
 }

--- a/src/screens/ScreenPokedex.module.css
+++ b/src/screens/ScreenPokedex.module.css
@@ -6,7 +6,7 @@
 
 .monsterGrid {
   display: grid;
-  gap: 1rem;
+  gap: 0 var(--padding3);
   grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
   margin: var(--padding3) 0;
   transition: 200ms opacity;

--- a/src/style/misc.css
+++ b/src/style/misc.css
@@ -117,28 +117,6 @@ input {
   word-break: break-all;
 }
 
-.fill-currentcolor {
-  fill: currentcolor;
-}
-
-.w0 {
-  width: 0;
-}
-
-.cursor-na {
-  cursor: not-allowed;
-}
-
-.fg-link {
-  color: var(--color-link);
-}
-
-@media (hover) {
-  .fg-link:hover {
-    color: var(--color-link-hover);
-  }
-}
-
 .tabular-nums {
   font-variant-numeric: tabular-nums;
 }

--- a/src/style/misc.css
+++ b/src/style/misc.css
@@ -190,17 +190,6 @@ input {
   background: var(--background-button-bg);
 }
 
-@media (hover) {
-  .button-bg:hover {
-    background: var(--background-button-bg-hover);
-    background: linear-gradient(
-      to bottom,
-      var(--color-button-hover1) 20%,
-      var(--color-button-hover1b)
-    );
-  }
-}
-
 .content-wide {
   max-width: 80rem;
 }
@@ -227,9 +216,9 @@ input {
 }
 
 .button-selected {
-  border-color: var(--color-accent);
-  background: var(--color-accent);
-  color: var(--color-bg1);
+  border-color: var(--color-vibrant-border);
+  background: var(--color-accent-bg);
+  color: var(--color-accent-fg);
 }
 
 .list-simple {

--- a/src/style/vars.css
+++ b/src/style/vars.css
@@ -9,7 +9,7 @@ something. */
   --hue-red: 0;
   --hue-teal: 200;
 
-  --color-bg1: hsl(var(--hue-blue) 5% 100%);
+  --color-bg1: hsl(var(--hue-blue) 10% 100%);
   --color-bg2: hsl(var(--hue-blue) 10% 90%);
   --color-fg1: hsl(var(--hue-blue) 15% 7%);
   --color-fg2: hsl(var(--hue-blue) 15% 20%);
@@ -24,8 +24,8 @@ something. */
   --color-header-text-shadow: hsl(var(--hue-blue) 5% 0% / 50%);
   --color-header-border1: hsl(var(--hue-blue) 5% 0% / 10%);
   --color-header-border2: hsl(var(--hue-blue) 5% 0% / 60%);
-  --color-button1: hsl(var(--hue-blue) 5% 100%);
-  --color-button1b: hsl(var(--hue-blue) 5% 96%);
+  --color-button1: hsl(var(--hue-blue) 10% 100%);
+  --color-button1b: hsl(var(--hue-blue) 10% 96%);
   --color-badge: hsl(var(--hue-green) 70% 30%);
   --color-link: hsl(var(--hue-blue) 100% 50%);
   --color-border1: hsl(var(--hue-blue) 10% 50%);

--- a/src/style/vars.css
+++ b/src/style/vars.css
@@ -11,7 +11,6 @@ something. */
 
   --color-bg1: hsl(var(--hue-blue) 5% 100%);
   --color-bg2: hsl(var(--hue-blue) 10% 90%);
-  --color-bg1b: hsl(var(--hue-blue) 5% 92%);
   --color-fg1: hsl(var(--hue-blue) 15% 7%);
   --color-fg2: hsl(var(--hue-blue) 15% 20%);
   --color-fg3: hsl(var(--hue-blue) 15% 40%);
@@ -29,7 +28,6 @@ something. */
   --color-button1b: hsl(var(--hue-blue) 5% 96%);
   --color-badge: hsl(var(--hue-green) 70% 30%);
   --color-link: hsl(var(--hue-blue) 100% 50%);
-  --color-link-hover: hsl(var(--hue-blue) 60% 60%);
   --color-border1: hsl(var(--hue-blue) 10% 50%);
   --color-border2: hsl(var(--hue-blue) 10% 70%);
   --color-border3: hsl(var(--hue-blue) 10% 80%);
@@ -63,16 +61,16 @@ something. */
     var(--color-button1);
 
   --padding0: 0;
-  --padding1: 0.25rem;
-  --padding2: 0.5rem;
-  --padding3: 1rem;
-  --padding4: 2rem;
-  --padding5: 4rem;
+  --padding1: 4px;
+  --padding2: 8px;
+  --padding3: 16px;
+  --padding4: 32px;
+  --padding5: 64px;
 
   --border-radius0: 0;
-  --border-radius1: 0.125rem;
-  --border-radius2: 0.5rem;
-  --border-radius3: 1rem;
+  --border-radius1: 2px;
+  --border-radius2: 8px;
+  --border-radius3: 16px;
   --border-radius-pill: 9999px;
 
   --shadow-button: 0 2px 2px rgb(0 0 0 / 10%);
@@ -113,9 +111,8 @@ something. */
 }
 
 [data-theme="dark"] {
-  --color-bg1: hsl(var(--hue-blue) 10% 22%);
+  --color-bg1: hsl(var(--hue-blue) 10% 26%);
   --color-bg2: hsl(var(--hue-blue) 10% 14%);
-  --color-bg1b: hsl(var(--hue-blue) 10% 18%);
   --color-fg1: hsl(var(--hue-blue) 15% 92%);
   --color-fg2: hsl(var(--hue-blue) 15% 82%);
   --color-fg3: hsl(var(--hue-blue) 15% 72%);
@@ -132,7 +129,6 @@ something. */
   --color-button1b: hsl(var(--hue-blue) 10% 22%);
   --color-badge: hsl(var(--hue-green) 60% 60%);
   --color-link: hsl(var(--hue-teal) 90% 75%);
-  --color-link-hover: hsl(var(--hue-blue) 80% 95%);
   --color-border1: hsl(var(--hue-blue) 10% 52%);
   --color-border2: hsl(var(--hue-blue) 10% 37%);
   --color-border3: hsl(var(--hue-blue) 10% 32%);
@@ -144,9 +140,8 @@ something. */
 }
 
 [data-theme="night"] {
-  --color-bg1: hsl(var(--hue-blue) 10% 10%);
+  --color-bg1: hsl(var(--hue-blue) 10% 15%);
   --color-bg2: hsl(var(--hue-blue) 10% 5%);
-  --color-bg1b: hsl(var(--hue-blue) 10% 9%);
   --color-fg1: hsl(var(--hue-blue) 15% 82%);
   --color-fg2: hsl(var(--hue-blue) 15% 72%);
   --color-fg3: hsl(var(--hue-blue) 15% 62%);
@@ -164,7 +159,6 @@ something. */
   --color-button1b: hsl(var(--hue-blue) 10% 14%);
   --color-badge: hsl(var(--hue-green) 60% 60%);
   --color-link: hsl(var(--hue-teal) 90% 75%);
-  --color-link-hover: hsl(var(--hue-blue) 80% 95%);
   --color-border1: hsl(var(--hue-blue) 10% 42%);
   --color-border2: hsl(var(--hue-blue) 10% 30%);
   --color-border3: hsl(var(--hue-blue) 10% 25%);
@@ -177,9 +171,8 @@ something. */
 
 @media (prefers-color-scheme: dark) {
   [data-theme="auto"] {
-    --color-bg1: hsl(var(--hue-blue) 10% 22%);
+    --color-bg1: hsl(var(--hue-blue) 10% 26%);
     --color-bg2: hsl(var(--hue-blue) 10% 14%);
-    --color-bg1b: hsl(var(--hue-blue) 10% 18%);
     --color-fg1: hsl(var(--hue-blue) 15% 92%);
     --color-fg2: hsl(var(--hue-blue) 15% 82%);
     --color-fg3: hsl(var(--hue-blue) 15% 72%);
@@ -196,7 +189,6 @@ something. */
     --color-button1b: hsl(var(--hue-blue) 10% 22%);
     --color-badge: hsl(var(--hue-green) 60% 60%);
     --color-link: hsl(var(--hue-teal) 90% 75%);
-    --color-link-hover: hsl(var(--hue-blue) 80% 95%);
     --color-border1: hsl(var(--hue-blue) 10% 52%);
     --color-border2: hsl(var(--hue-blue) 10% 37%);
     --color-border3: hsl(var(--hue-blue) 10% 32%);

--- a/src/style/vars.css
+++ b/src/style/vars.css
@@ -4,34 +4,39 @@ something. */
 
 :root,
 [data-theme="light"] {
-  --color-bg1: hsl(240 5% 100%);
-  --color-bg2: hsl(240 10% 90%);
-  --color-fg1: hsl(240 15% 7%);
-  --color-fg2: hsl(240 15% 20%);
-  --color-fg3: hsl(240 15% 40%);
-  --color-fg4: hsl(240 15% 60%);
-  --color-accent: hsl(240 15% 20%);
-  --color-header-dark: hsl(0 90% 15%);
-  --color-header-base: hsl(0 90% 35%);
-  --color-header-highlight: hsl(0 80% 65%);
+  --hue-blue: 240;
+  --hue-green: 120;
+  --hue-red: 0;
+  --hue-teal: 200;
+
+  --color-bg1: hsl(var(--hue-blue) 5% 100%);
+  --color-bg2: hsl(var(--hue-blue) 10% 90%);
+  --color-bg1b: hsl(var(--hue-blue) 5% 92%);
+  --color-fg1: hsl(var(--hue-blue) 15% 7%);
+  --color-fg2: hsl(var(--hue-blue) 15% 20%);
+  --color-fg3: hsl(var(--hue-blue) 15% 40%);
+  --color-fg4: hsl(var(--hue-blue) 15% 60%);
+  --color-accent-bg: hsl(var(--hue-blue) 15% 20%);
+  --color-accent-fg: hsl(var(--hue-blue) 5% 100%);
+  --color-header-dark: hsl(var(--hue-red) 90% 15%);
+  --color-header-base: hsl(var(--hue-red) 90% 35%);
+  --color-header-highlight: hsl(var(--hue-red) 80% 65%);
   --color-header-text: #fff;
-  --color-header-text-shadow: hsl(240 5% 0% / 50%);
-  --color-header-border1: hsl(240 5% 0% / 10%);
-  --color-header-border2: hsl(240 5% 0% / 60%);
-  --color-button1: hsl(240 5% 100%);
-  --color-button1b: hsl(240 5% 96%);
-  --color-button-hover1: hsl(200 80% 96%);
-  --color-button-hover1b: hsl(200 80% 92%);
-  --color-badge: hsl(120 70% 30%);
-  --color-link: hsl(240 100% 50%);
-  --color-link-hover: hsl(240 60% 60%);
-  --color-border1: hsl(240 5% 55%);
-  --color-border2: hsl(240 5% 70%);
-  --color-border3: hsl(240 5% 80%);
-  --color-vibrant-border: hsl(0 0% 0% / 20%);
-  --color-vibrant-border1: hsl(0 0% 0% / 60%);
-  --color-scroll-fg: hsl(240 5% 20%);
-  --color-scroll-bg: hsl(240 5% 85%);
+  --color-header-text-shadow: hsl(var(--hue-blue) 5% 0% / 50%);
+  --color-header-border1: hsl(var(--hue-blue) 5% 0% / 10%);
+  --color-header-border2: hsl(var(--hue-blue) 5% 0% / 60%);
+  --color-button1: hsl(var(--hue-blue) 5% 100%);
+  --color-button1b: hsl(var(--hue-blue) 5% 96%);
+  --color-badge: hsl(var(--hue-green) 70% 30%);
+  --color-link: hsl(var(--hue-blue) 100% 50%);
+  --color-link-hover: hsl(var(--hue-blue) 60% 60%);
+  --color-border1: hsl(var(--hue-blue) 10% 50%);
+  --color-border2: hsl(var(--hue-blue) 10% 70%);
+  --color-border3: hsl(var(--hue-blue) 10% 80%);
+  --color-vibrant-border: hsl(var(--hue-red) 0% 0% / 20%);
+  --color-vibrant-border1: hsl(var(--hue-red) 0% 0% / 60%);
+  --color-scroll-fg: hsl(var(--hue-blue) 10% 20%);
+  --color-scroll-bg: hsl(var(--hue-blue) 10% 85%);
 
   --weight-normal: 400;
   --weight-medium: 500;
@@ -52,15 +57,10 @@ something. */
       var(--color-header-base);
 
   --background-button-bg: linear-gradient(
-      var(--color-button1) 0 50%,
-      var(--color-button1b) 50%
+      var(--color-button1),
+      var(--color-button1b)
     )
     var(--color-button1);
-  --background-button-bg-hover: linear-gradient(
-      var(--color-button-hover1) 0 50%,
-      var(--color-button-hover1b) 50%
-    )
-    var(--color-button-hover1);
 
   --padding0: 0;
   --padding1: 0.25rem;
@@ -75,13 +75,13 @@ something. */
   --border-radius3: 1rem;
   --border-radius-pill: 9999px;
 
-  --shadow-button: 0 2px 4px rgb(0 0 0 / 10%);
+  --shadow-button: 0 2px 2px rgb(0 0 0 / 10%);
   --shadow-inset: inset 0 2px 4px rgb(0 0 0 / 10%);
 
   --filter-darken: brightness(90%);
-  --filter-image: drop-shadow(0 0 2px hsl(0 0% 100% / 20%))
-    drop-shadow(4px 4px 16px hsl(0 0% 0% / 20%))
-    drop-shadow(8px 8px 32px hsl(0 0% 0% / 10%));
+  --filter-image: drop-shadow(0 0 2px hsl(var(--hue-red) 0% 100% / 20%))
+    drop-shadow(4px 4px 16px hsl(var(--hue-red) 0% 0% / 20%))
+    drop-shadow(8px 8px 32px hsl(var(--hue-red) 0% 0% / 10%));
 
   --font-size0: 0.875rem;
   --font-size1: 1rem;
@@ -113,97 +113,97 @@ something. */
 }
 
 [data-theme="dark"] {
-  --color-bg1: hsl(240 10% 22%);
-  --color-bg2: hsl(240 10% 14%);
-  --color-fg1: hsl(240 15% 92%);
-  --color-fg2: hsl(240 15% 82%);
-  --color-fg3: hsl(240 15% 72%);
-  --color-fg4: hsl(240 15% 62%);
-  --color-accent: hsl(240 15% 82%);
-  --color-header-base: hsl(0 60% 35%);
-  --color-header-highlight: hsl(0 60% 55%);
+  --color-bg1: hsl(var(--hue-blue) 10% 22%);
+  --color-bg2: hsl(var(--hue-blue) 10% 14%);
+  --color-bg1b: hsl(var(--hue-blue) 10% 18%);
+  --color-fg1: hsl(var(--hue-blue) 15% 92%);
+  --color-fg2: hsl(var(--hue-blue) 15% 82%);
+  --color-fg3: hsl(var(--hue-blue) 15% 72%);
+  --color-fg4: hsl(var(--hue-blue) 15% 62%);
+  --color-accent-bg: hsl(var(--hue-blue) 15% 82%);
+  --color-accent-fg: hsl(var(--hue-blue) 10% 7%);
+  --color-header-base: hsl(var(--hue-red) 60% 35%);
+  --color-header-highlight: hsl(var(--hue-red) 60% 55%);
   --color-header-text: #fff;
-  --color-header-text-shadow: hsl(240 5% 0% / 50%);
-  --color-header-border1: hsl(240 5% 100% / 20%);
-  --color-header-border2: hsl(240 5% 100% / 50%);
-  --color-button1: hsl(240 5% 26%);
-  --color-button1b: hsl(240 5% 22%);
-  --color-button-hover1: hsl(200 30% 32%);
-  --color-button-hover1b: hsl(200 30% 26%);
-  --color-badge: hsl(120 60% 60%);
-  --color-link: hsl(200 90% 75%);
-  --color-link-hover: hsl(240 80% 95%);
-  --color-border1: hsl(240 5% 52%);
-  --color-border2: hsl(240 5% 37%);
-  --color-border3: hsl(240 5% 32%);
-  --color-vibrant-border: hsl(0 0% 100% / 40%);
-  --color-vibrant-border1: hsl(0 0% 100% / 80%);
-  --color-scroll-fg: hsl(240 5% 70%);
-  --color-scroll-bg: hsl(240 5% 15%);
+  --color-header-text-shadow: hsl(var(--hue-blue) 5% 0% / 50%);
+  --color-header-border1: hsl(var(--hue-blue) 5% 100% / 20%);
+  --color-header-border2: hsl(var(--hue-blue) 5% 100% / 50%);
+  --color-button1: hsl(var(--hue-blue) 10% 26%);
+  --color-button1b: hsl(var(--hue-blue) 10% 22%);
+  --color-badge: hsl(var(--hue-green) 60% 60%);
+  --color-link: hsl(var(--hue-teal) 90% 75%);
+  --color-link-hover: hsl(var(--hue-blue) 80% 95%);
+  --color-border1: hsl(var(--hue-blue) 10% 52%);
+  --color-border2: hsl(var(--hue-blue) 10% 37%);
+  --color-border3: hsl(var(--hue-blue) 10% 32%);
+  --color-vibrant-border: hsl(var(--hue-red) 0% 100% / 40%);
+  --color-vibrant-border1: hsl(var(--hue-red) 0% 100% / 80%);
+  --color-scroll-fg: hsl(var(--hue-blue) 10% 70%);
+  --color-scroll-bg: hsl(var(--hue-blue) 10% 15%);
   color-scheme: dark;
 }
 
 [data-theme="night"] {
-  --color-bg1: hsl(240 10% 10%);
-  --color-bg2: hsl(240 10% 5%);
-  --color-fg1: hsl(240 15% 82%);
-  --color-fg2: hsl(240 15% 72%);
-  --color-fg3: hsl(240 15% 62%);
-  --color-fg4: hsl(240 15% 52%);
-  --color-accent: hsl(240 15% 72%);
-  --color-header-dark: hsl(240 5% 5%);
-  --color-header-base: hsl(240 5% 10%);
-  --color-header-highlight: hsl(240 5% 20%);
-  --color-header-text: hsl(240 5% 82%);
-  --color-header-text-shadow: hsl(240 5% 0% / 50%);
-  --color-header-border1: hsl(240 5% 100% / 5%);
-  --color-header-border2: hsl(240 5% 100% / 20%);
-  --color-button1: hsl(240 5% 18%);
-  --color-button1b: hsl(240 5% 14%);
-  --color-button-hover1: hsl(200 30% 20%);
-  --color-button-hover1b: hsl(200 30% 14%);
-  --color-badge: hsl(120 60% 60%);
-  --color-link: hsl(200 90% 75%);
-  --color-link-hover: hsl(240 80% 95%);
-  --color-border1: hsl(240 5% 36%);
-  --color-border2: hsl(240 5% 30%);
-  --color-border3: hsl(240 5% 25%);
-  --color-vibrant-border: hsl(0 0% 100% / 40%);
-  --color-vibrant-border1: hsl(0 0% 100% / 80%);
-  --color-scroll-fg: hsl(240 5% 62%);
-  --color-scroll-bg: hsl(240 5% 5%);
+  --color-bg1: hsl(var(--hue-blue) 10% 10%);
+  --color-bg2: hsl(var(--hue-blue) 10% 5%);
+  --color-bg1b: hsl(var(--hue-blue) 10% 9%);
+  --color-fg1: hsl(var(--hue-blue) 15% 82%);
+  --color-fg2: hsl(var(--hue-blue) 15% 72%);
+  --color-fg3: hsl(var(--hue-blue) 15% 62%);
+  --color-fg4: hsl(var(--hue-blue) 15% 52%);
+  --color-accent-bg: hsl(var(--hue-blue) 15% 72%);
+  --color-accent-fg: hsl(var(--hue-blue) 15% 5%);
+  --color-header-dark: hsl(var(--hue-blue) 5% 5%);
+  --color-header-base: hsl(var(--hue-blue) 5% 10%);
+  --color-header-highlight: hsl(var(--hue-blue) 5% 20%);
+  --color-header-text: hsl(var(--hue-blue) 5% 82%);
+  --color-header-text-shadow: hsl(var(--hue-blue) 5% 0% / 50%);
+  --color-header-border1: hsl(var(--hue-blue) 5% 100% / 5%);
+  --color-header-border2: hsl(var(--hue-blue) 5% 100% / 20%);
+  --color-button1: hsl(var(--hue-blue) 10% 18%);
+  --color-button1b: hsl(var(--hue-blue) 10% 14%);
+  --color-badge: hsl(var(--hue-green) 60% 60%);
+  --color-link: hsl(var(--hue-teal) 90% 75%);
+  --color-link-hover: hsl(var(--hue-blue) 80% 95%);
+  --color-border1: hsl(var(--hue-blue) 10% 42%);
+  --color-border2: hsl(var(--hue-blue) 10% 30%);
+  --color-border3: hsl(var(--hue-blue) 10% 25%);
+  --color-vibrant-border: hsl(var(--hue-red) 0% 100% / 50%);
+  --color-vibrant-border1: hsl(var(--hue-red) 0% 100% / 80%);
+  --color-scroll-fg: hsl(var(--hue-blue) 10% 62%);
+  --color-scroll-bg: hsl(var(--hue-blue) 10% 5%);
   color-scheme: dark;
 }
 
 @media (prefers-color-scheme: dark) {
   [data-theme="auto"] {
-    --color-bg1: hsl(240 10% 22%);
-    --color-bg2: hsl(240 10% 14%);
-    --color-fg1: hsl(240 15% 92%);
-    --color-fg2: hsl(240 15% 82%);
-    --color-fg3: hsl(240 15% 72%);
-    --color-fg4: hsl(240 15% 62%);
-    --color-accent: hsl(240 15% 82%);
-    --color-header-base: hsl(0 60% 35%);
-    --color-header-highlight: hsl(0 60% 55%);
+    --color-bg1: hsl(var(--hue-blue) 10% 22%);
+    --color-bg2: hsl(var(--hue-blue) 10% 14%);
+    --color-bg1b: hsl(var(--hue-blue) 10% 18%);
+    --color-fg1: hsl(var(--hue-blue) 15% 92%);
+    --color-fg2: hsl(var(--hue-blue) 15% 82%);
+    --color-fg3: hsl(var(--hue-blue) 15% 72%);
+    --color-fg4: hsl(var(--hue-blue) 15% 62%);
+    --color-accent-bg: hsl(var(--hue-blue) 15% 82%);
+    --color-accent-fg: hsl(var(--hue-blue) 10% 7%);
+    --color-header-base: hsl(var(--hue-red) 60% 35%);
+    --color-header-highlight: hsl(var(--hue-red) 60% 55%);
     --color-header-text: #fff;
-    --color-header-text-shadow: hsl(240 5% 0% / 50%);
-    --color-header-border1: hsl(240 5% 100% / 20%);
-    --color-header-border2: hsl(240 5% 100% / 50%);
-    --color-button1: hsl(240 5% 26%);
-    --color-button1b: hsl(240 5% 22%);
-    --color-button-hover1: hsl(200 30% 32%);
-    --color-button-hover1b: hsl(200 30% 26%);
-    --color-badge: hsl(120 60% 60%);
-    --color-link: hsl(200 90% 75%);
-    --color-link-hover: hsl(240 80% 95%);
-    --color-border1: hsl(240 5% 52%);
-    --color-border2: hsl(240 5% 37%);
-    --color-border3: hsl(240 5% 32%);
-    --color-vibrant-border: hsl(0 0% 100% / 40%);
-    --color-vibrant-border1: hsl(0 0% 100% / 80%);
-    --color-scroll-fg: hsl(240 5% 70%);
-    --color-scroll-bg: hsl(240 5% 15%);
+    --color-header-text-shadow: hsl(var(--hue-blue) 5% 0% / 50%);
+    --color-header-border1: hsl(var(--hue-blue) 5% 100% / 20%);
+    --color-header-border2: hsl(var(--hue-blue) 5% 100% / 50%);
+    --color-button1: hsl(var(--hue-blue) 10% 26%);
+    --color-button1b: hsl(var(--hue-blue) 10% 22%);
+    --color-badge: hsl(var(--hue-green) 60% 60%);
+    --color-link: hsl(var(--hue-teal) 90% 75%);
+    --color-link-hover: hsl(var(--hue-blue) 80% 95%);
+    --color-border1: hsl(var(--hue-blue) 10% 52%);
+    --color-border2: hsl(var(--hue-blue) 10% 37%);
+    --color-border3: hsl(var(--hue-blue) 10% 32%);
+    --color-vibrant-border: hsl(var(--hue-red) 0% 100% / 40%);
+    --color-vibrant-border1: hsl(var(--hue-red) 0% 100% / 80%);
+    --color-scroll-fg: hsl(var(--hue-blue) 10% 70%);
+    --color-scroll-bg: hsl(var(--hue-blue) 10% 15%);
     color-scheme: dark;
   }
 }


### PR DESCRIPTION
## 2025-06-26

- Removed the shiny gradient on buttons, it was too distracting

  - It's just a subtle regular gradient now

- Updated the color scheme to be blue tinted again

  - Yes, you were right, person who emailed me about this

- Further refined the Pokédex card styles

- Updated the Defense Team page styles to better match the Pokédex card styles

  - There was a lot of wasted space and visual noise on that page before

  - I think it's easier to read now

  - I also changed the size at which it switches to two column mode, so the team
    edit area has more room
